### PR TITLE
Release features GH action

### DIFF
--- a/.github/workflows/release-features.yaml
+++ b/.github/workflows/release-features.yaml
@@ -1,0 +1,24 @@
+name: "Release devcontainer features"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Publish"
+        uses: devcontainers/action@v1
+        with:
+          publish-features: "true"
+          base-path-to-features: "./features"
+          features-namespace: "devcontainer/features"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Create github actions workflow for releasing features

This workflow uses the [devcontainers/action](https://github.com/devcontainers/action) action to release devcontainer features.

Given this setup, pushes to main will kick off this workflow, which will release any features that have had their version (in `devcontainer-feature.json`) updated.