### PR TITLE
Add a default for the version option

### DIFF
--- a/features/ruby/devcontainer-feature.json
+++ b/features/ruby/devcontainer-feature.json
@@ -19,6 +19,7 @@
     "options": {
         "version": {
             "type": "string",
+            "default": "3.3.0",
             "description": "The ruby version to be installed"
         }
     }


### PR DESCRIPTION
Publishing the feature failed with some schema validation errors: https://github.com/rails/devcontainer/actions/runs/8116445483/job/22186482114#step:3:71

It seems that the github action expects there to be either an `enum`, `proposal` or `default` in for each of the children in the `options` array. ([source](https://github.com/devcontainers/action/blob/85693cddf23e12779168aead7403ab84642a4b9a/src/schemas/devContainerFeature.schema.json#L225))

However, this seems wrong because both [the docs](https://containers.dev/implementors/features/#options-property) and the [implementation on the devcontainer cli](https://github.com/devcontainers/cli/blob/30d2105e3b277f6c33808500b1ebef881b414b20/src/spec-configuration/containerFeaturesConfiguration.ts#L86) list them as optional. I should be able to have a string option with no default and no enum / proposal options. 

I want to avoid listing all the options since we will have to release a new version of the feature for every patch ruby version.

So for now it seems the best option is to add a default, altho longterm I don't think we want it. People should be explicit about the ruby version always IMO.

I will open an issue / PR to the github action to try to fix this issue. But just want to get something working for now.