### PR TITLE
Add node to the ruby image

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -49,6 +49,6 @@ jobs:
         with:
           imageName: ghcr.io/rails/devcontainer/images/ruby
           cacheFrom: ghcr.io/rails/devcontainer/images/ruby
-          imageTag: 0.1.0-${{ matrix.RUBY_VERSION }}
+          imageTag: 0.2.0-${{ matrix.RUBY_VERSION }}
           subFolder: images/ruby
           push: always

--- a/images/ruby/.devcontainer/devcontainer.json
+++ b/images/ruby/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
     },
     "ghcr.io/rails/devcontainer/features/ruby:0.1.0": {
       "version": "${localEnv:RUBY_VERSION}"
-    }
+    },
+    "ghcr.io/devcontainers/features/node:1": "none"
   },
   // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode"


### PR DESCRIPTION
We need node installed on the Docker image for the Rails devcontainer [Dockerfile](https://github.com/rails/rails/blob/4bb73233413f30fd7217bd7f08af44963f5832b1/.devcontainer/Dockerfile#L49) (not the Rails app devcontainer). So we can include it in the image here using the node feature. This matches [the implementation of microsoft's ruby image](https://github.com/devcontainers/images/blob/cdb8f1f1a51e084dbf5c12e296ec34050dd98c3a/src/ruby/.devcontainer/devcontainer.json#L15).

Note, the process for versioning the image is still pretty manual but it's ok for now. I am prioritizing just getting an image published that can work with the Rails and Rails app devcontainers.