### PR TITLE
feat: ✨ add install option for `libpq-dev` to support postgresql

### DIFF
--- a/features/ruby/devcontainer-feature.json
+++ b/features/ruby/devcontainer-feature.json
@@ -21,6 +21,11 @@
             "type": "string",
             "default": "3.3.0",
             "description": "The ruby version to be installed"
+        },
+        "installLibPq": {
+            "type": "boolean",
+            "default": false,
+            "description": "Install `libpq-dev` for PostgreSQL support?"
         }
     }
 }

--- a/features/ruby/install.sh
+++ b/features/ruby/install.sh
@@ -1,7 +1,12 @@
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
+INSTALL_LIB_PQ="${INSTALLLIBPQ:-"false"}"
+
 
 apt-get update -y
 apt-get -y install --no-install-recommends libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+if [[ "$INSTALL_LIB_PQ" == "true" ]]; then
+    apt-get -y install --no-install-recommends libpq-dev
+fi
 
 git clone https://github.com/rbenv/rbenv.git /usr/local/share/rbenv
 git clone https://github.com/rbenv/ruby-build.git /usr/local/share/ruby-build


### PR DESCRIPTION
I was working on a `rbenv` based devcontainer (due to some issues with `ruby-lsp` not working in the `rvm` based alternative) the last week when I encountered your repository. 

This PR is adding an option to install `libpq-dev` to enable installation of postgresql as an alternative to sqlite.

Another way to resolve this, would be to have another "feature" install the package, i.e.
```json
 "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
      "packages": [
          "libpq-dev"
      ]
  }
```

but I rather prefer it to happen at the same place. 
