### PR TITLE
Publish image to non-versioned tag

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -49,6 +49,8 @@ jobs:
         with:
           imageName: ghcr.io/rails/devcontainer/images/ruby
           cacheFrom: ghcr.io/rails/devcontainer/images/ruby
-          imageTag: 0.1.0-${{ matrix.RUBY_VERSION }}
+          imageTag:
+            - 0.1.0-${{ matrix.RUBY_VERSION }}
+            - ${{ matrix.RUBY_VERSION }} ]
           subFolder: images/ruby
           push: always


### PR DESCRIPTION
I want to the image to be versioned. But I think we should also publish the "latest" version of the image to a tag with just the ruby version. That way we can have the rail devcontainer point to that tag and not have to update it everytime we bump the image version to fix issues.

So for example, if we release version 0.2.0 of the image for ruby 3.3.0, we will update two tags:

ghcr.io/rails/devcontainer/images/ruby:0.2.0-3.3.0
ghcr.io/rails/devcontainer/images/ruby:3.3.0