### PR TITLE
Build the image for amd64 and arm64 platforms

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -49,6 +49,7 @@ jobs:
         with:
           imageName: ghcr.io/rails/devcontainer/images/ruby
           cacheFrom: ghcr.io/rails/devcontainer/images/ruby
-          imageTag: 0.2.0-${{ matrix.RUBY_VERSION }},${{ matrix.RUBY_VERSION }}
+          imageTag: 0.3.0-${{ matrix.RUBY_VERSION }},${{ matrix.RUBY_VERSION }}
           subFolder: images/ruby
           push: always
+          platform: linux/arm64,linux/amd64


### PR DESCRIPTION
While testing this image with the rails devcontainer, I hit a segfault in active storage tests due to [a known issue with libvips on x86](https://github.com/libvips/ruby-vips/issues/264).

It made me realise we are not building this image for arm64.

This change to the workflow for building the image should build a multi-platform image, so developers working on `arm64` will not run into this problem.