### PR TITLE
Add libxml2 to ruby feature

### DIFF
--- a/features/ruby/devcontainer-feature.json
+++ b/features/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "name": "Ruby (via rbenv)",
     "description": "Installs Ruby, rbenv, ruby-build and libraries needed to build Ruby",
     "customizations": {

--- a/features/ruby/install.sh
+++ b/features/ruby/install.sh
@@ -1,7 +1,8 @@
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 
 apt-get update -y
-apt-get -y install --no-install-recommends libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+apt-get -y install --no-install-recommends libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential \
+ libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev libxml2-dev
 
 git clone https://github.com/rbenv/rbenv.git /usr/local/share/rbenv
 git clone https://github.com/rbenv/ruby-build.git /usr/local/share/ruby-build


### PR DESCRIPTION
In rails/rails@7f8e0af I had to add `libxml2` to the Dockerfile when switching to use the image based on this feature.

Now that I think about it I think we just always want `libxml` to come with ruby.