### PR TITLE
Update the image's devcontainer to not specify a version for the ruby…

### DIFF
--- a/images/ruby/.devcontainer/devcontainer.json
+++ b/images/ruby/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
       "version": "latest",
       "ppa": "false"
     },
-    "ghcr.io/rails/devcontainer/features/ruby:0.2.0": {
+    "ghcr.io/rails/devcontainer/features/ruby": {
       "version": "${localEnv:RUBY_VERSION}"
     }
   },


### PR DESCRIPTION
We always want to build the image with the latest version of the feature. This saves us from having to remember to update it and potentially building it with an outdated version.