### PR TITLE
Create feature for activestorage dependencies

### DIFF
--- a/features/activestorage/README.md
+++ b/features/activestorage/README.md
@@ -1,0 +1,23 @@
+# Active Storage
+
+Installs libvips, ffmpeg and poppler-utils which are required to use Active Storage for Rails apps.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/rails/devcontainer/features/activestorage": {}
+}
+```
+
+## Options
+
+## Customizations
+
+### VS Code Extensions
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.

--- a/features/activestorage/devcontainer-feature.json
+++ b/features/activestorage/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+    "id": "activestorage",
+    "version": "0.1.0",
+    "name": "Active Storage",
+    "description": "Installs utilities needed for Rails Active Storage"
+}

--- a/features/activestorage/install.sh
+++ b/features/activestorage/install.sh
@@ -1,0 +1,11 @@
+apt-get update -qq && \
+  apt-get install --no-install-recommends -y \
+    libvips \
+    #  For video thumbnails
+    ffmpeg \
+    # For pdf thumbnails. If you want to use mupdf instead of poppler,
+    # you can install the following packages instead:
+    # mupdf mupdf-tools
+    poppler-utils
+
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Create a feature that includes the dependencies needed for active storage.

This will make it easier to compose the features we need in the devcontainer json when creating a new rails app, or installing active storage, instead of needing to modify a dockerfile.