### PR TITLE
Create a feature for mysql client dependencies

### DIFF
--- a/features/mysql-client/README.md
+++ b/features/mysql-client/README.md
@@ -1,0 +1,24 @@
+# MySQL Client
+
+Installs needed client-side dependencies for Rails apps using MySQL.
+
+NOTE: This feature does not install the dependencies needed for the MySQL Server. For that we recommend running a
+service using the official [MySQL docker image](https://hub.docker.com/_/mysql).
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/rails/devcontainer/features/mysql-client": {}
+}
+```
+
+## Options
+
+## Customizations
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.

--- a/features/mysql-client/devcontainer-feature.json
+++ b/features/mysql-client/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+    "id": "mysql-client",
+    "version": "0.1.0",
+    "name": "MySQL Client",
+    "description": "Installs needed client-side dependencies for Rails apps using MySQL"
+}

--- a/features/mysql-client/install.sh
+++ b/features/mysql-client/install.sh
@@ -1,0 +1,3 @@
+apt-get update -y && apt-get -y install --no-install-recommends default-libmysqlclient-dev
+
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This feature installs the client-side dependencies needed for a Rails app running mysql.

In the rails app defualt devcontainer, mysql will be running in its own service (using the official mysql docker image). The rails app container will need these libraries installed to connect to the server (via the mysql2 gem).

Packaging this as a feature makes it easy to compose the appropriate libraries needed when generating / configuring a rails app - instead of modifying app's dockerfile.