### PR TITLE
Create a feature for installing postgres client dependencies

### DIFF
--- a/features/postgres-client/README.md
+++ b/features/postgres-client/README.md
@@ -1,0 +1,24 @@
+# Postgres Client
+
+Installs needed client-side dependencies for Rails apps using Postgres.
+
+NOTE: This feature does not install the dependencies needed for the Postgres server. For that we recommend running a
+service using the official [Postgres docker image](https://hub.docker.com/_/postgres).
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/rails/devcontainer/features/postgres-client": {}
+}
+```
+
+## Options
+
+## Customizations
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.

--- a/features/postgres-client/devcontainer-feature.json
+++ b/features/postgres-client/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+    "id": "postgres-client",
+    "version": "0.1.0",
+    "name": "Postgres Client",
+    "description": "Installs needed client-side dependencies for Rails apps using Postgres"
+}

--- a/features/postgres-client/install.sh
+++ b/features/postgres-client/install.sh
@@ -1,0 +1,3 @@
+apt-get update -y && apt-get -y install --no-install-recommends libpq-dev
+
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This feature installs the client-side dependencies needed for a Rails app running postgres.

In the rails app defualt devcontainer, postgres will be running in its own service (using the official postgres docker image). The rails app container will need these libraries installed to connect to the server (via the pg gem).

Packaging this as a feature makes it easy to compose the appropriate libraries needed when generating / configuring a rails app - instead of modifying app's dockerfile.