### PR TITLE
[Proposal] Create `bun` devcontainer feature

### DIFF
--- a/features/bun/devcontainer-feature.json
+++ b/features/bun/devcontainer-feature.json
@@ -1,0 +1,16 @@
+{
+    "id": "bun",
+    "version": "0.1.0",
+    "name": "Bun",
+    "description": "Installs Bun. Bun is an all-in-one JavaScript runtime & toolkit designed for speed, complete with a bundler, test runner, and Node.js-compatible package manager.",
+    "installsAfter": [
+      "ghcr.io/devcontainers/features/common-utils"
+    ],
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "1.0.1",
+            "description": "The bun version to be installed"
+        }
+    }
+}

--- a/features/bun/install.sh
+++ b/features/bun/install.sh
@@ -1,0 +1,4 @@
+# Install Bun
+export BUN_INSTALL=/usr/local
+
+curl -fsSL https://bun.sh/install | bash -s -- "bun-v${VERSION}"


### PR DESCRIPTION
This commit creates a new feature that will install bun in a devcontainer.

https://github.com/rails/rails/pull/51520 this PR adds node to rails devcontainer.json generated file if node is required. I thought on add the same for bun if using bun so I thought that would be better to create a devcontainer feature for it instead of adding it to Dockerfile. Wdyt?

The default version 1.0.1 is the same added on rails app https://github.com/rails/rails/blob/64fadc6ffe2cdb9c3fe5e880a49356d3d3a19e2d/railties/lib/rails/generators/app_base.rb#L20