### PR TITLE
Add postgresql-client to postgresql-client feature

### DIFF
--- a/features/postgres-client/install.sh
+++ b/features/postgres-client/install.sh
@@ -1,3 +1,3 @@
-apt-get update -y && apt-get -y install --no-install-recommends libpq-dev
+apt-get update -y && apt-get -y install --no-install-recommends libpq-dev postgresql-client
 
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Currently when you generate an App with postgres and access the devcontainer, it fails to run `bin/rails db` inside the container terminal because there is no `psql` installed on it. This commit installs postgresql-client so it can be used inside the devcontainer.

Before installing postgresql-client:

```shell
vscode ➜ /workspaces/demo_devcontainer (main) $ bin/rails db
Couldn't find database client: psql. Check your $PATH and try again.
```

after 

```shell
vscode ➜ /workspaces/demo_devcontainer (main) $ bin/rails db
Password for user postgres: 
psql (15.6 (Debian 15.6-0+deb12u1), server 15.1 (Debian 15.1-1.pgdg110+1))
Type "help" for help.

demo_devcontainer_development=# 
```

does it make sense to install postgresql-client on the feature? 

Thanks