### PR TITLE
Create SQLite3 feature

### DIFF
--- a/features/sqlite3/README.md
+++ b/features/sqlite3/README.md
@@ -1,0 +1,21 @@
+# SQLite3
+
+Installs needed dependencies for Rails apps using SQLite3.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/rails/devcontainer/features/sqlite3": {}
+}
+```
+
+## Options
+
+## Customizations
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.

--- a/features/sqlite3/devcontainer-feature.json
+++ b/features/sqlite3/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+    "id": "sqlite3",
+    "version": "0.1.0",
+    "name": "SQLite3",
+    "description": "Installs needed dependencies for Rails apps using SQLite3"
+}

--- a/features/sqlite3/install.sh
+++ b/features/sqlite3/install.sh
@@ -1,0 +1,3 @@
+apt-get update -y && apt-get -y install --no-install-recommends pkg-config libsqlite3-dev sqlite3
+
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Create a feature for SQLite3 dependencies.

I noticed we can only install the sqlite3 gem on rails apps because we have `pkg-config` installed by `lib-vips`. And, we don't have the client available. So let's put those dependencies in their own feature like postgres and mysql.