### PR TITLE
Specify Rust version 1.77 in ruby image devcontainer

### DIFF
--- a/features/activestorage/install.sh
+++ b/features/activestorage/install.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 apt-get update -qq && \
   apt-get install --no-install-recommends -y \
     libvips \

--- a/features/mysql-client/install.sh
+++ b/features/mysql-client/install.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 apt-get update -y && apt-get -y install --no-install-recommends default-libmysqlclient-dev
 
 rm -rf /var/lib/apt/lists/*

--- a/features/postgres-client/install.sh
+++ b/features/postgres-client/install.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 apt-get update -y && apt-get -y install --no-install-recommends libpq-dev postgresql-client
 
 rm -rf /var/lib/apt/lists/*

--- a/features/ruby/install.sh
+++ b/features/ruby/install.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 
 apt-get update -y

--- a/features/sqlite3/install.sh
+++ b/features/sqlite3/install.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 apt-get update -y && apt-get -y install --no-install-recommends pkg-config libsqlite3-dev sqlite3
 
 rm -rf /var/lib/apt/lists/*

--- a/images/ruby/.devcontainer/devcontainer.json
+++ b/images/ruby/.devcontainer/devcontainer.json
@@ -17,6 +17,9 @@
     },
     "ghcr.io/rails/devcontainer/features/ruby": {
       "version": "${localEnv:RUBY_VERSION}"
+    },
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "1.77"
     }
   },
   // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.


### PR DESCRIPTION
There is an issue installing Ruby with Rust 1.78 on arm64. For now we will lock this image to 1.77 while that issue is investigated.