### PR TITLE
Build fewer Ruby images

### DIFF
--- a/.github/workflows/publish-new-image-version.yaml
+++ b/.github/workflows/publish-new-image-version.yaml
@@ -13,18 +13,8 @@ jobs:
       matrix:
         RUBY_VERSION:
           - 3.3.1
-          - 3.3.0
           - 3.2.4
-          - 3.2.3
-          - 3.2.2
-          - 3.2.1
-          - 3.2.0
           - 3.1.5
-          - 3.1.4
-          - 3.1.3
-          - 3.1.2
-          - 3.1.1
-          - 3.1.0
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
For Rails 7.2, we will only support the latest patch version of the supported minor Ruby versions.