### PR TITLE
Install Debian's rustc package instead of the devcontainer rust feature

### DIFF
--- a/.github/workflows/test-ruby-feature.yaml
+++ b/.github/workflows/test-ruby-feature.yaml
@@ -29,4 +29,4 @@ jobs:
           cacheFrom: ghcr.io/rails/devcontainer/test-ruby-feature
           subFolder: .github
           refFilterForPush: refs/heads/main
-          runCmd: ruby -v || ( echo "Ruby is not installed."; exit 1 )
+          runCmd: RUBY_YJIT_ENABLE=1 ruby -v | grep +YJIT || ( echo "Ruby is not installed."; exit 1 )

--- a/features/ruby/devcontainer-feature.json
+++ b/features/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "name": "Ruby (via rbenv)",
     "description": "Installs Ruby, rbenv, ruby-build and libraries needed to build Ruby",
     "customizations": {
@@ -16,13 +16,10 @@
     "installsAfter": [
         "ghcr.io/devcontainers/features/common-utils"
     ],
-    "dependsOn": {
-        "ghcr.io/devcontainers/features/rust": {}
-    },
     "options": {
         "version": {
             "type": "string",
-            "default": "3.3.0",
+            "default": "3.3.1",
             "description": "The ruby version to be installed"
         }
     }

--- a/features/ruby/install.sh
+++ b/features/ruby/install.sh
@@ -5,7 +5,7 @@ USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 
 apt-get update -y
 apt-get -y install --no-install-recommends libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential \
- libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev libxml2-dev
+ libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev libxml2-dev rustc
 
 git clone https://github.com/rbenv/rbenv.git /usr/local/share/rbenv
 git clone https://github.com/rbenv/ruby-build.git /usr/local/share/ruby-build

--- a/images/ruby/.devcontainer/devcontainer.json
+++ b/images/ruby/.devcontainer/devcontainer.json
@@ -18,9 +18,6 @@
     "ghcr.io/rails/devcontainer/features/ruby": {
       "version": "${localEnv:RUBY_VERSION}"
     },
-    "ghcr.io/devcontainers/features/rust:1": {
-      "version": "1.77"
-    }
   },
   // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode"


### PR DESCRIPTION
https://github.com/rails/devcontainer/issues/32

Just installing rustc is a lighter weight way of installing Rust without compiling, and does not introduce the rust-related vscode extensions installed by the feature which are unecessary for most ruby development. This gives us rust version 1.63, which is acceptable for now. If we need a specific version in the future we may need to compile rust ourselves.

While I am here I made 3.3.1 the default for the ruby feature.
