### PR TITLE
Initialize rbenv if zshrc exists

### DIFF
--- a/features/ruby/install.sh
+++ b/features/ruby/install.sh
@@ -21,6 +21,10 @@ if [ "${USERNAME}" != "root" ]; then
     chmod -R g+r+w "/home/${USERNAME}/.rbenv"
 
     echo 'eval "$(rbenv init -)"' >> /home/${USERNAME}/.bashrc
+
+    if [ -f /home/${USERNAME}/.zshrc ]; then
+        echo 'eval "$(rbenv init -)"' >> /home/${USERNAME}/.zshrc
+    fi
 fi
 
 su ${USERNAME} -c "rbenv install $VERSION"


### PR DESCRIPTION
`ghcr.io/devcontainers/features/common-utils` DevContainer feature allows you to setup `zsh` as a default shell, but `ghcr.io/rails/devcontainer/features/ruby` feature is not adding `eval "$(rbenv init -)"` to `.zshrc` if it exists. This PR adds `eval "$(rbenv init -)"` to `.zshrc` if it exists in the DevContainer image.

Currently, to handle this case in my setup, I'm prepending the following 2 lines into my `setup.sh` post create script:

```bash
echo 'eval "$(rbenv init -)"' >> /home/vscode/.zshrc
eval "$(rbenv init -)"
```