### PR TITLE
Bump default ruby version

### DIFF
--- a/features/ruby/devcontainer-feature.json
+++ b/features/ruby/devcontainer-feature.json
@@ -19,7 +19,7 @@
     "options": {
         "version": {
             "type": "string",
-            "default": "3.3.1",
+            "default": "3.3.3",
             "description": "The ruby version to be installed"
         }
     }

--- a/features/ruby/devcontainer-feature.json
+++ b/features/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "Ruby (via rbenv)",
     "description": "Installs Ruby, rbenv, ruby-build and libraries needed to build Ruby",
     "customizations": {


### PR DESCRIPTION
Let's make Ruby 3.3.3 the default for the feature.

And bump the feature version which includes some other recent changes.