### PR TITLE
mysql-client: Use default-mysql-client instead of default-libmysqlclient-dev

### DIFF
--- a/features/mysql-client/devcontainer-feature.json
+++ b/features/mysql-client/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "mysql-client",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "name": "MySQL Client",
     "description": "Installs needed client-side dependencies for Rails apps using MySQL"
 }

--- a/features/mysql-client/install.sh
+++ b/features/mysql-client/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
-apt-get update -y && apt-get -y install --no-install-recommends default-libmysqlclient-dev
+apt-get update -y && apt-get -y install --no-install-recommends default-mysql-client
 
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Rails apps using `structure.sql` need to use `mysqldump` when setting up the db and running migrations. That is provided by  `default-mysql-client`.