### PR TITLE
Install OhMyZsh and set Zsh as default shell

### DIFF
--- a/images/ruby/.devcontainer/devcontainer.json
+++ b/images/ruby/.devcontainer/devcontainer.json
@@ -6,6 +6,8 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {
       "installZsh": "true",
+      "installOhMyZsh": "true",
+      "configureZshAsDefaultShell": "true",
       "username": "vscode",
       "userUid": "1000",
       "userGid": "1000",


### PR DESCRIPTION
The Rails/Ruby image installs Zsh, but it is not configuring it as default. This change sets it as default, and also installs OhMyZsh. DevContainer users can set Zsh as default shell using a post creation script, but it requires multiple lines of bash script as implemented [here](https://github.com/devcontainers/features/blob/main/src/common-utils/main.sh#L493-L503). So, setting it the as default shell is easier. Also, as far as I know, DevContainer users can't override image feature settings, so if there is a place to do this change is inside the image build.