### PR TITLE
mysql-client: add default-libmysqlclient-dev package

### DIFF
--- a/features/mysql-client/install.sh
+++ b/features/mysql-client/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
-apt-get update -y && apt-get -y install --no-install-recommends default-mysql-client
+apt-get update -y && apt-get -y install --no-install-recommends default-mysql-client default-libmysqlclient-dev
 
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
default-libmysqlclient-dev must be installed to avoid the library/headers missing error.

```
-----
mysql client is missing. You may need to 'sudo apt-get install libmariadb-dev', 'sudo apt-get install libmysqlclient-dev' or 'sudo yum install mysql-devel', and try again.
-----
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```