### PR TITLE
Bump Mysql feature to 1.1.1

### DIFF
--- a/features/mysql-client/devcontainer-feature.json
+++ b/features/mysql-client/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "mysql-client",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "MySQL Client",
     "description": "Installs needed client-side dependencies for Rails apps using MySQL"
 }


### PR DESCRIPTION
This version adds back default-libmysqlclient-dev which was incorrectly removed from last version.