### PR TITLE
[Cleanup] Ruby: Do not install libreadline-dev dependency twice

### DIFF
--- a/features/ruby/install.sh
+++ b/features/ruby/install.sh
@@ -5,7 +5,7 @@ USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 
 apt-get update -y
 apt-get -y install --no-install-recommends libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential \
- libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev libxml2-dev rustc
+ libyaml-dev libncurses5-dev libffi-dev libgdbm-dev libxml2-dev rustc
 
 git clone https://github.com/rbenv/rbenv.git /usr/local/share/rbenv
 git clone https://github.com/rbenv/ruby-build.git /usr/local/share/ruby-build


### PR DESCRIPTION
`libreadline-dev` is getting installed twice. I have DRY the code and remove it's redundant occurence.

**Original**

https://github.com/rails/devcontainer/blob/7beef0a10ff8b9216b219deeba0dcb145b50fa29/features/ruby/install.sh#L6-L9

**Modified**

```shell
apt-get update -y
apt-get -y install --no-install-recommends libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential \
 libyaml-dev libncurses5-dev libffi-dev libgdbm-dev libxml2-dev rustc
```
