### PR TITLE
Feature 'variantProcessor' Option Description

### DIFF
--- a/features/activestorage/README.md
+++ b/features/activestorage/README.md
@@ -12,6 +12,10 @@ Installs libvips, ffmpeg and poppler-utils which are required to use Active Stor
 
 ## Options
 
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| variantProcessor | The image processing library to use with Active Storage | string | vips |
+
 ## Customizations
 
 ### VS Code Extensions

--- a/features/activestorage/devcontainer-feature.json
+++ b/features/activestorage/devcontainer-feature.json
@@ -1,6 +1,17 @@
 {
     "id": "activestorage",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "name": "Active Storage",
-    "description": "Installs utilities needed for Rails Active Storage"
+    "description": "Installs utilities needed for Rails Active Storage",
+    "options": {
+        "variantProcessor": {
+            "type": "string",
+            "proposals": [
+                "vips",
+                "mini_magick"
+            ],
+            "default": "vips",
+            "description": "The image processing library to use with Active Storage"
+        }
+    }
 }

--- a/features/activestorage/install.sh
+++ b/features/activestorage/install.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
+if [ "$VARIANTPROCESSOR" = "mini_magick"]; then
+  IMAGE_PROCESSOR="imagemagick"
+else
+  IMAGE_PROCESSOR="libvips"
+fi
+
 apt-get update -qq && \
   apt-get install --no-install-recommends -y \
-    libvips \
+    $IMAGE_PROCESSOR \
     ffmpeg \
     poppler-utils
 


### PR DESCRIPTION
# Description
This pull request introduces a new option called `variantProcessor` for the Active Storage feature. This option allows users to specify the image processing library they want to use, with the default set to `vips`. The available options are `vips` and `mini_magick`.

# Changes Made

- **README.md**: Added documentation for the new `variantProcessor` option.
- **devcontainer-feature.json**: Updated the version and added the `variantProcessor` option with its type, proposals, and default value.
- **install.sh**: Modified the installation script to check the `VARIANTPROCESSOR` environment variable and set the appropriate image processor.

# Motivation

The `variantProcessor` in Rails' Active Storage originally supports both `vips` and `mini_magick`. However, this feature only supported `vips`. This PR aims to enhance the functionality by adding support for `mini_magick`, providing users with more flexibility in choosing their preferred image processing library.