### PR TITLE
Add bundler cache feature

### DIFF
--- a/features/bundler-cache/README.md
+++ b/features/bundler-cache/README.md
@@ -1,0 +1,19 @@
+# Bundler cache
+
+Creates a volume for persisting the installed gems across different containers.
+
+## Example Usage
+
+```json
+"features": {
+  "ghcr.io/rails/devcontainer/features/bundler-cache:1": {}
+}
+```
+
+## Options
+
+## Customizations
+
+## OS Support
+
+`bash` is required to execute the `install.sh` script.

--- a/features/bundler-cache/devcontainer-feature.json
+++ b/features/bundler-cache/devcontainer-feature.json
@@ -1,0 +1,17 @@
+{
+  "id": "bundler-cache",
+  "version": "1.0.0",
+  "name": "Bundler cache",
+  "description": "Creates a volume for persisting the installed gems across different containers",
+  "containerEnv": {
+    "BUNDLE_PATH": "/bundle/vendor"
+  },
+  "mounts": [
+    {
+      "source": "bundler-data",
+      "target": "/bundle",
+      "type": "volume"
+    }
+  ],
+  "postCreateCommand": "/usr/local/share/bundler-data-permissions.sh"
+}

--- a/features/bundler-cache/install.sh
+++ b/features/bundler-cache/install.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
+
+POST_CREATE_COMMAND_SCRIPT_PATH="/usr/local/share/bundler-data-permissions.sh"
+
+tee "$POST_CREATE_COMMAND_SCRIPT_PATH" > /dev/null \
+<< EOF
+#!/bin/sh
+set -e
+sudo chown -R ${USERNAME} /bundle
+EOF
+
+chmod 755 "$POST_CREATE_COMMAND_SCRIPT_PATH"


### PR DESCRIPTION
Hello!

I've been using docker and docker compose for years to run my rails apps in development. The way I used docker + docker compose was to run a single process and remove the container after it's done (eg `docker compose run --rm ...`, or just `docker compose up` and them removing the container, etc). And when you're adding gems, trying things out, etc. it's super useful to have a volume for the installed gems so you can run `docker compose run web bundle` and have the new gems available rather than having to rebuild the image over and over.

Devcontainers approach, ie developing inside of the container, is really interesting but there's something that slows down the whole thing of bringing the container up and that is to install gems every time (if you remove containers after a period of time obviously, if you don't you're fine).

This feature could've been in its own repo but I thought this is a good place to be as people like me might find useful.

This feature just creates a volume that gets mounted in `/bundle` and adds the `BUNDLE_PATH` env var to `/vendor/bundle`. This way you might remove the container and when you bring it up again it will use the gems you already have installed, making the whole process faster. The reason why there's a postCreateCommand is that the mounted volume needs to be owned by the vscode user, as the devcontainer doesn't run as root. I couldn't find a different way editing the compose.yaml or devcontainer.json. Apologies if there's another way!