### PR TITLE
Explicitly set the user to vscode in the Ruby image Dockerfile

### DIFF
--- a/images/ruby/.devcontainer/Dockerfile
+++ b/images/ruby/.devcontainer/Dockerfile
@@ -3,3 +3,5 @@ FROM mcr.microsoft.com/devcontainers/base:1-bookworm
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common
+
+USER vscode


### PR DESCRIPTION
Since the metadata from devcontainer.json is not present in the image, other Dev Container implementations will not set this user (which is default for vscode and created by the debian base image). So lets explicitly set it so that those Dev Container implementations use the right user when using this image.