### PR TITLE
Ensure binding is always `0.0.0.0`.

### DIFF
--- a/images/ruby/.devcontainer/Dockerfile
+++ b/images/ruby/.devcontainer/Dockerfile
@@ -3,3 +3,7 @@ FROM mcr.microsoft.com/devcontainers/base:1-bookworm
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common
+
+# Ensure binding is always 0.0.0.0
+# Binds the server to all IP addresses of the container, so it can be accessed from outside the container.
+ENV BINDING="0.0.0.0"


### PR DESCRIPTION
### Description

This PR updates the Dockerfile to ensure the Rails server binds to all available IP addresses (`0.0.0.0`). This change allows the Rails app to be accessed externally from outside the container.

For a working example of this configuration in action, you can refer to [https://github.com/viktorianer/rails8-devcontainer-enhancements/pull/5](https://github.com/viktorianer/rails8-devcontainer-enhancements/pull/5). This showcases the same binding solution applied in a Rails app.

### Why this is needed

While the default binding to `localhost` works with Docker in most cases, issues can arise when using alternative container runtimes like **Podman**. These runtimes may restrict access to services inside containers when they are bound only to `localhost`. By explicitly setting the binding to `0.0.0.0`, the Rails app becomes accessible externally on port 3000 across all runtimes, including Podman.

### Impact

- **Fix for Podman and other alternative runtimes**: Resolves issues where the Rails app could not be accessed from outside the container.
- The Rails app will now be reachable on `http://localhost:3000` from external connections.

