### PR TITLE
Simplify bundler cache feature

### DIFF
--- a/features/bundler-cache/devcontainer-feature.json
+++ b/features/bundler-cache/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "bundler-cache",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Bundler cache",
   "description": "Creates a volume for persisting the installed gems across different containers",
   "containerEnv": {
@@ -13,5 +13,5 @@
       "type": "volume"
     }
   ],
-  "postCreateCommand": "/usr/local/share/bundler-data-permissions.sh"
+  "postCreateCommand": "sudo chown -R ${USER} /bundle"
 }

--- a/features/bundler-cache/install.sh
+++ b/features/bundler-cache/install.sh
@@ -1,16 +1,1 @@
-#!/bin/sh
-
-set -e
-
-USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
-
-POST_CREATE_COMMAND_SCRIPT_PATH="/usr/local/share/bundler-data-permissions.sh"
-
-tee "$POST_CREATE_COMMAND_SCRIPT_PATH" > /dev/null \
-<< EOF
-#!/bin/sh
-set -e
-sudo chown -R ${USERNAME} /bundle
-EOF
-
-chmod 755 "$POST_CREATE_COMMAND_SCRIPT_PATH"
+# This is a no op


### PR DESCRIPTION
Based on https://github.com/rails/devcontainer/issues/53 I think we can simplify this feature. Let's not create a script in `install.sh`. It's a one liner so we can just call it inline in the `postCreateCommand`.