### PR TITLE
Add `LANG` and `LC_ALL` environment variables.

### DIFF
--- a/images/ruby/.devcontainer/Dockerfile
+++ b/images/ruby/.devcontainer/Dockerfile
@@ -4,4 +4,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common
 
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
 USER vscode


### PR DESCRIPTION
### Motivation / Background

This change is required to address encoding issues in the Ruby Dev Container (running with CLI), specifically when running e.g.,  RuboCop on files containing non-ASCII characters. Without explicitly setting `LANG` and `LC_ALL` to `C.UTF-8`, developers may encounter errors like `invalid byte sequence in US-ASCII`. This change aligns the Rails development environment with UTF-8, enhancing compatibility with encoding-sensitive tools.

Currently, there is no unified approach for setting locale variables across language-specific Dev Containers in the Microsoft Dev Containers repository. Each language image individually manages its encoding settings, leading to inconsistencies. This PR adds the locale settings directly to the Ruby container, following a similar approach used in other language-specific Dev Containers.

### Detail

This PR adds `LANG` and `LC_ALL` environment variables set to `C.UTF-8`. This configuration provides a UTF-8-compatible locale by default, resolving encoding issues for Ruby and Rails applications. 

Example:

Before:

```
vscode ➜ $ /app bin/rubocop -AS
Inspecting 94 files
..

2 files inspected, no offenses detected
invalid byte sequence in US-ASCII
/home/vscode/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rubocop-md-1.2.4/lib/rubocop/markdown/preprocess.rb:49:in `gsub!'
...
bin/rubocop:27:in `load'
bin/rubocop:27:in `<main>'
```

After:

```
vscode ➜ /app $ bin/rubocop -AS
Inspecting 94 files
.................C..................C......C.....C....................................C..C....

Offenses:
...
94 files inspected, 14 offenses detected, 14 offenses corrected
```

### Additional Information

This solution is implemented specifically in the Rails Dev Container to provide a consistent UTF-8 encoding environment. While other language images may handle locale independently, adding these settings here ensures compatibility with Rails development without affecting unrelated configurations. Similar adjustments have been seen in other Dev Container images, such as [#417](https://github.com/devcontainers/images/pull/417) and more https://github.com/search?q=repo%3Adevcontainers%2Fimages+LANG+LC_ALL+&type=code. 

In contrast, see also https://github.com/microsoft/vscode-remote-release/issues/2169.
