### PR TITLE
Install missing libpq-dev package

### DIFF
--- a/features/postgres-client/install.sh
+++ b/features/postgres-client/install.sh
@@ -8,9 +8,9 @@ apt-get update -qq
 VERSION_EXISTS=$(apt-cache search --names-only postgresql-client-$POSTGRES_CLIENT_VERSION | wc -l)
 
 if [ "$VERSION_EXISTS" -ge 1 ]; then
-  apt-get install --no-install-recommends -y postgresql-client-$POSTGRES_CLIENT_VERSION
+  apt-get install --no-install-recommends -y libpq-dev postgresql-client-$POSTGRES_CLIENT_VERSION
 else
-  apt-get install --no-install-recommends -y postgresql-common
+  apt-get install --no-install-recommends -y postgresql-common libpq-dev
   /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && apt-get install --no-install-recommends -y postgresql-client-$POSTGRES_CLIENT_VERSION
 fi
 


### PR DESCRIPTION
Closes #63

The latest postgresql-client feature no longer installs `libpq-dev` which is required for the `pg` gem install properly.