### PR TITLE
add default `build.options` to specify platform for image & feature building

### DIFF
--- a/images/ruby/.devcontainer/devcontainer.json
+++ b/images/ruby/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "dockerfile": "./Dockerfile",
-    "context": "."
+    "context": ".",
+    "options": ["--platform=linux/amd64"]
   },
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {


### PR DESCRIPTION
Proposed fix for #76 

Not sure of a cleaner way to fix the arch building differences when `run_args` will not be sufficient in applying the setting to the features

```json
{
	"image": "ghcr.io/rails/devcontainer/images/ruby:3.3.0",
	"runArgs": ["--platform=linux/amd64"],
...
}
```