### PR TITLE
🐛 Fix version option in postgres-client feature

### DIFF
--- a/features/postgres-client/devcontainer-feature.json
+++ b/features/postgres-client/devcontainer-feature.json
@@ -1,6 +1,13 @@
 {
     "id": "postgres-client",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Postgres Client",
-    "description": "Installs needed client-side dependencies for Rails apps using Postgres"
+    "description": "Installs needed client-side dependencies for Rails apps using Postgres",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "15",
+            "description": "The postgres client version to be installed"
+        }
+    }
 }


### PR DESCRIPTION
Hi,

Although in Pull Request #60 the use of the environment variable `$VERSION` was implemented to allow the choice of the version of `postgres-client`, it does not seem to work and my suspicion is due to not having the specification that this variable is a feature option.