### PR TITLE
Add Ruby 3.4.3 and set it as the default version

### DIFF
--- a/.github/workflows/publish-new-image-version.yaml
+++ b/.github/workflows/publish-new-image-version.yaml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         RUBY_VERSION:
+          - 3.4.3
           - 3.4.2
           - 3.4.1
           - 3.4.0

--- a/features/ruby/devcontainer-feature.json
+++ b/features/ruby/devcontainer-feature.json
@@ -19,7 +19,7 @@
     "options": {
         "version": {
             "type": "string",
-            "default": "3.4.1",
+            "default": "3.4.3",
             "description": "The ruby version to be installed"
         }
     }


### PR DESCRIPTION
This pull request adds Ruby 3.4.3 and set it as the default version.

- Ruby 3.4.3 Released
https://www.ruby-lang.org/en/news/2025/04/14/ruby-3-4-3-released/