### PR TITLE
Add Ruby 3.4.7

### DIFF
--- a/.github/workflows/publish-new-image-version.yaml
+++ b/.github/workflows/publish-new-image-version.yaml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         RUBY_VERSION:
+          - 3.4.7
           - 3.4.6
           - 3.4.5
           - 3.4.4

--- a/features/src/ruby/devcontainer-feature.json
+++ b/features/src/ruby/devcontainer-feature.json
@@ -18,7 +18,7 @@
     "options": {
         "version": {
             "type": "string",
-            "default": "3.4.6",
+            "default": "3.4.7",
             "description": "The ruby version to be installed"
         },
         "versionManager": {

--- a/features/test/ruby/test.sh
+++ b/features/test/ruby/test.sh
@@ -8,6 +8,6 @@ check "mise is installed" bash -c "mise --version"
 check "mise init is sourced in the bashrc" bash -c "grep 'eval \"\$(~/.local/bin/mise activate bash)\"' $HOME/.bashrc"
 check "mise idiomatic version file is enabled for ruby" bash -c "mise settings | grep idiomatic_version_file_enable_tools | grep ruby"
 check "Ruby is installed with YJIT" bash -c "RUBY_YJIT_ENABLE=1 ruby -v | grep +YJIT"
-check "Ruby version is set to 3.4.6" bash -c "mise use -g ruby | grep 3.4.6"
+check "Ruby version is set to 3.4.7" bash -c "mise use -g ruby | grep 3.4.7"
 
 reportResults

--- a/features/test/ruby/with_rbenv.sh
+++ b/features/test/ruby/with_rbenv.sh
@@ -9,6 +9,6 @@ check "rbenv is installed" bash -c "rbenv --version"
 check "ruby-build is installed" bash -c "ls -l $HOME/.rbenv/plugins/ruby-build | grep '\-> /usr/local/share/ruby-build'"
 eval "$(rbenv init -)"
 check "Ruby is installed with YJIT" bash -c "RUBY_YJIT_ENABLE=1 ruby -v | grep +YJIT"
-check "Ruby version is set to 3.4.6" bash -c "rbenv global | grep 3.4.6"
+check "Ruby version is set to 3.4.7" bash -c "rbenv global | grep 3.4.7"
 
 reportResults


### PR DESCRIPTION
Simply adds/upgrades to the latest Ruby 3.4.7.
- https://www.ruby-lang.org/en/news/2025/10/07/ruby-3-4-7-released/
- https://github.com/ruby/ruby/releases/tag/v3_4_7

Approach is based on @rafaelfranca's https://github.com/rails/devcontainer/commit/845288ce6ebc271909795019e3f7915e2b25f69c but I did not bump the version as I figured I'd leave that up to the maintainers to do since I believe they need to tag the release/version-bump commit as well.

Inspired by me trying to unbreak my other upgrade PR here.
- https://github.com/rails/rails/pull/55872