### PR TITLE
Add Herb LSP extension to `ruby` devcontainer feature

### DIFF
--- a/features/src/ruby/README.md
+++ b/features/src/ruby/README.md
@@ -47,7 +47,8 @@ Installs Ruby and a version manager (mise or rbenv) along with the dependencies 
 
 ### VS Code Extensions
 
-- `shopify.ruby-lsp`
+- [`shopify.ruby-lsp`](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
+- [`marcoroth.herb-lsp`](https://marketplace.visualstudio.com/items?itemName=marcoroth.herb-lsp)
 
 ## OS Support
 

--- a/features/src/ruby/devcontainer-feature.json
+++ b/features/src/ruby/devcontainer-feature.json
@@ -8,7 +8,8 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "shopify.ruby-lsp"
+                "shopify.ruby-lsp",
+                "marcoroth.herb-lsp"
             ]
         }
     },


### PR DESCRIPTION
After talking to @rafaelfranca we agreed to adding the Herb LSP VS Code Extension to the devcontainer setup so more people can start using it in their day-to-day work.

The [Herb Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=marcoroth.herb-lsp) is specifically designed to work with HTML+ERB files and is built on top of the [HTML-aware ERB parser, called Herb](https://marcoroth.dev/posts/introducing-herb). 

The [Herb Language Server](https://herb-tools.dev/projects/language-server) currently offers the functionality to catch HTML/Ruby syntax errors in HTML+ERB files (using [Prism](https://github.com/ruby/prism)), run the [Herb Linter](https://herb-tools.dev/projects/linter) to catch common issues/enforce best practices, and auto-format HTML+ERB documents on-save using the [Herb Formatter](https://herb-tools.dev/projects/formatter). There's a lot more to come.

To follow along, to report issues, or to share feature ideas you can open an issue on the [Herb](https://github.com/marcoroth/herb) here on GitHub. Thank you!