### PR TITLE
Add Ruby 3.4.8

### DIFF
--- a/.github/workflows/publish-new-image-version.yaml
+++ b/.github/workflows/publish-new-image-version.yaml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         RUBY_VERSION:
+          - 3.4.8
           - 3.4.7
           - 3.4.6
           - 3.4.5

--- a/features/src/ruby/devcontainer-feature.json
+++ b/features/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "name": "Ruby",
     "description": "Installs Ruby and a version manager (mise or rbenv) along with libraries needed to build Ruby.",
     "documentationURL": "https://github.com/rails/devcontainer/tree/main/features/src/ruby",
@@ -19,7 +19,7 @@
     "options": {
         "version": {
             "type": "string",
-            "default": "3.4.7",
+            "default": "3.4.8",
             "description": "The ruby version to be installed"
         },
         "versionManager": {

--- a/features/test/ruby/test.sh
+++ b/features/test/ruby/test.sh
@@ -8,6 +8,6 @@ check "mise is installed" bash -c "mise --version"
 check "mise init is sourced in the bashrc" bash -c "grep 'eval \"\$(~/.local/bin/mise activate bash)\"' $HOME/.bashrc"
 check "mise idiomatic version file is enabled for ruby" bash -c "mise settings | grep idiomatic_version_file_enable_tools | grep ruby"
 check "Ruby is installed with YJIT" bash -c "RUBY_YJIT_ENABLE=1 ruby -v | grep +YJIT"
-check "Ruby version is set to 3.4.7" bash -c "mise use -g ruby | grep 3.4.7"
+check "Ruby version is set to 3.4.8" bash -c "mise use -g ruby | grep 3.4.8"
 
 reportResults

--- a/features/test/ruby/with_rbenv.sh
+++ b/features/test/ruby/with_rbenv.sh
@@ -9,6 +9,6 @@ check "rbenv is installed" bash -c "rbenv --version"
 check "ruby-build is installed" bash -c "ls -l $HOME/.rbenv/plugins/ruby-build | grep '\-> /usr/local/share/ruby-build'"
 eval "$(rbenv init -)"
 check "Ruby is installed with YJIT" bash -c "RUBY_YJIT_ENABLE=1 ruby -v | grep +YJIT"
-check "Ruby version is set to 3.4.7" bash -c "rbenv global | grep 3.4.7"
+check "Ruby version is set to 3.4.8" bash -c "rbenv global | grep 3.4.8"
 
 reportResults


### PR DESCRIPTION
## Change

This PR adds Ruby 3.4.8 support and updates the default Ruby version to 3.4.8.

  ## References
  - Ruby 3.4.8 release: https://www.ruby-lang.org/en/news/2024/12/03/ruby-3-4-8-released/
  - Similar to #97 which added Ruby 3.4.7 support