### PR TITLE
Add Ruby 4.0.1

### DIFF
--- a/.github/workflows/publish-new-image-version.yaml
+++ b/.github/workflows/publish-new-image-version.yaml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         RUBY_VERSION:
+          - 4.0.1
           - 4.0.0
           - 3.4.8
           - 3.4.7

--- a/features/src/ruby/README.md
+++ b/features/src/ruby/README.md
@@ -40,7 +40,7 @@ Installs Ruby and a version manager (mise or rbenv) along with the dependencies 
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| version | The version of ruby to be installed | string | 4.0.0 |
+| version | The version of ruby to be installed | string | 4.0.1 |
 | versionManager | The version manager to use for Ruby (mise or rbenv) | string | mise |
 
 ## Customizations

--- a/features/src/ruby/devcontainer-feature.json
+++ b/features/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "name": "Ruby",
     "description": "Installs Ruby and a version manager (mise or rbenv) along with libraries needed to build Ruby.",
     "documentationURL": "https://github.com/rails/devcontainer/tree/main/features/src/ruby",
@@ -19,7 +19,7 @@
     "options": {
         "version": {
             "type": "string",
-            "default": "4.0.0",
+            "default": "4.0.1",
             "description": "The ruby version to be installed"
         },
         "versionManager": {

--- a/features/test/ruby/test.sh
+++ b/features/test/ruby/test.sh
@@ -8,6 +8,6 @@ check "mise is installed" bash -c "mise --version"
 check "mise init is sourced in the bashrc" bash -c "grep 'eval \"\$(~/.local/bin/mise activate bash)\"' $HOME/.bashrc"
 check "mise idiomatic version file is enabled for ruby" bash -c "mise settings | grep idiomatic_version_file_enable_tools | grep ruby"
 check "Ruby is installed with YJIT" bash -c "RUBY_YJIT_ENABLE=1 ruby -v | grep +YJIT"
-check "Ruby version is set to 4.0.0" bash -c "mise use -g ruby | grep 4.0.0"
+check "Ruby version is set to 4.0.1" bash -c "mise use -g ruby | grep 4.0.1"
 
 reportResults

--- a/features/test/ruby/with_rbenv.sh
+++ b/features/test/ruby/with_rbenv.sh
@@ -9,6 +9,6 @@ check "rbenv is installed" bash -c "rbenv --version"
 check "ruby-build is installed" bash -c "ls -l $HOME/.rbenv/plugins/ruby-build | grep '\-> /usr/local/share/ruby-build'"
 eval "$(rbenv init -)"
 check "Ruby is installed with YJIT" bash -c "RUBY_YJIT_ENABLE=1 ruby -v | grep +YJIT"
-check "Ruby version is set to 4.0.0" bash -c "rbenv global | grep 4.0.0"
+check "Ruby version is set to 4.0.1" bash -c "rbenv global | grep 4.0.1"
 
 reportResults


### PR DESCRIPTION
Following the release of Ruby 4.0.1, I created a PR to support it in devcontainers.


https://www.ruby-lang.org/en/news/2026/01/13/ruby-4-0-1-released/