### PR TITLE
Default to postgres-client-17

### DIFF
--- a/features/src/postgres-client/README.md
+++ b/features/src/postgres-client/README.md
@@ -16,7 +16,7 @@ service using the official [Postgres docker image](https://hub.docker.com/_/post
 ## Options
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| version | The postgres-client version | string | 15 |
+| version | The postgres-client version | string | 17 |
 
 ## Customizations
 

--- a/features/src/postgres-client/devcontainer-feature.json
+++ b/features/src/postgres-client/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "postgres-client",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "name": "Postgres Client",
     "description": "Installs needed client-side dependencies for Rails apps using Postgres.",
     "documentationURL": "https://github.com/rails/devcontainer/tree/main/features/src/postgres-client",
@@ -8,7 +8,7 @@
     "options": {
         "version": {
             "type": "string",
-            "default": "15",
+            "default": "17",
             "description": "The postgres client version to be installed"
         }
     }

--- a/features/src/postgres-client/install.sh
+++ b/features/src/postgres-client/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-export POSTGRES_CLIENT_VERSION="${VERSION:-"15"}"
+export POSTGRES_CLIENT_VERSION="${VERSION:-"17"}"
 
 apt-get update -qq
 

--- a/features/test/postgres-client/scenarios.json
+++ b/features/test/postgres-client/scenarios.json
@@ -1,17 +1,17 @@
 {
-  "version_16": {
+  "version_18": {
       "image": "mcr.microsoft.com/devcontainers/base:2-trixie",
       "features": {
           "postgres-client": {
-            "version": "16"
+            "version": "18"
           }
       }
   },
-  "version_14": {
+  "version_16": {
     "image": "mcr.microsoft.com/devcontainers/base:2-trixie",
     "features": {
       "postgres-client": {
-        "version": "14"
+        "version": "16"
       }
     }
   }

--- a/features/test/postgres-client/test.sh
+++ b/features/test/postgres-client/test.sh
@@ -5,7 +5,7 @@ set -e
 source dev-container-features-test-lib
 
 check "PostgreSQL client is installed" bash -c "psql --version"
-check "PostgreSQL version is 15" bash -c "psql --version | grep -q 'psql (PostgreSQL) 15'"
+check "PostgreSQL version is 17" bash -c "psql --version | grep -q 'psql (PostgreSQL) 17'"
 check "libpq-dev is installed" bash -c "dpkg -l | grep libpq-dev"
 
 reportResults

--- a/features/test/postgres-client/version_18.sh
+++ b/features/test/postgres-client/version_18.sh
@@ -5,7 +5,7 @@ set -e
 source dev-container-features-test-lib
 
 check "PostgreSQL client is installed" bash -c "psql --version"
-check "PostgreSQL version is 14" bash -c "psql --version | grep -q 'psql (PostgreSQL) 14'"
+check "PostgreSQL version is 18" bash -c "psql --version | grep -q 'psql (PostgreSQL) 18'"
 check "libpq-dev is installed" bash -c "dpkg -l | grep libpq-dev"
 
 reportResults


### PR DESCRIPTION
I think that when basing the image on Trixie, going for Postgres Client v17 by default makes most sense.

References:
- https://packages.debian.org/en/trixie/postgresql-client

I am not sure about the version bump convention at play, does this justify a major version bump? 